### PR TITLE
feat: Include source maps to builds

### DIFF
--- a/packages/infrastructure/webpack-for-js/src/webpack.config.js
+++ b/packages/infrastructure/webpack-for-js/src/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: './index.js',
   target: 'node',
   mode: 'production',
+  devtool: 'source-map',
 
   performance: {
     maxEntrypointSize: 20000,


### PR DESCRIPTION
Webpack docs recommend `source-map` option for production builds.

See:
- https://webpack.js.org/configuration/devtool/