### PR TITLE
Fix-get-injectable-with-generic-lifecycle

### DIFF
--- a/packages/injectable/core/index.d.ts
+++ b/packages/injectable/core/index.d.ts
@@ -84,41 +84,24 @@ export interface Injectable<
     InstantiationParam
   >;
   readonly instantiate: Instantiate<InjectionInstance, InstantiationParam>;
-  readonly lifecycle: ILifecycle<InstantiationParam>;
+  readonly lifecycle: Lifecycle<InstantiationParam>;
   readonly decorable?: boolean;
   readonly tags?: any[];
   readonly scope?: boolean;
 }
 
-type InjectableLifecycle<InstantiationParam> = InstantiationParam extends void
-  ? {
-      lifecycle?: ILifecycle<void>;
-    }
-  : {
-      lifecycle: ILifecycle<InstantiationParam>;
-    };
+export type GetInjectableOptionsWithoutInstantiationParameter<I extends TI, TI> = Omit<Injectable<I, TI, void>, "lifecycle"> & {
+  lifecycle?: Lifecycle<void>;
+}
 
-type GetInjectableOptions<
-  InjectionInstance extends InjectionTokenInstance,
-  InjectionTokenInstance,
-  InstantiationParam,
-> = InjectableLifecycle<InstantiationParam> &
-  Omit<
-    Injectable<InjectionInstance, InjectionTokenInstance, InstantiationParam>,
-    'lifecycle'
-  >;
+export type GetInjectableOptionsWithInstantiationParameter<I extends TI, TI, P> = Injectable<I, TI, P>;
 
-export function getInjectable<
-  InjectionInstance extends InjectionTokenInstance,
-  InjectionTokenInstance,
-  InstantiationParam = void,
->(
-  options: GetInjectableOptions<
-    InjectionInstance,
-    InjectionTokenInstance,
-    InstantiationParam
-  >,
-): Injectable<InjectionInstance, InjectionTokenInstance, InstantiationParam>;
+export interface GetInjectable{
+  <I extends TI, TI>(options: GetInjectableOptionsWithoutInstantiationParameter<I, TI>): Injectable<I, TI, void>;
+  <I extends TI, TI, P>(options: GetInjectableOptionsWithInstantiationParameter<I, TI, P>): Injectable<I, TI, P>;
+}
+
+export const getInjectable: GetInjectable;
 
 export type InjectableBunch<InjectableConfig extends object> = InjectableConfig;
 
@@ -289,7 +272,7 @@ export interface DiContainerForInjection {
   ) => boolean;
 }
 
-export interface ILifecycle<InstantiationParam> {
+export interface Lifecycle<InstantiationParam> {
   getInstanceKey: (di: DiContainer, params: InstantiationParam) => any;
 }
 
@@ -302,7 +285,7 @@ export const lifecycleEnum: {
   };
 
   keyedSingleton<InstantiationParam>(
-    options: ILifecycle<InstantiationParam>,
+    options: Lifecycle<InstantiationParam>,
   ): typeof options;
 
   transient: {

--- a/packages/injectable/core/index.test-d.ts
+++ b/packages/injectable/core/index.test-d.ts
@@ -12,6 +12,7 @@ import {
   getKeyedSingletonCompositeKey,
   getSpecificInjectionToken,
   getTypedSpecifier,
+  Lifecycle,
   Injectable,
   InjectableBunch,
   injectionDecoratorToken,
@@ -857,3 +858,10 @@ expectAssignable<TypedSpecifier<string, { someSpeciality: "some-type" }>>(typedS
 
 // given typed specifier, TypedSpecifierWithType is compatible with "extends" and type inference
 expectAssignable<TypedSpecifierWithType<"someSpeciality", "some-type">>(typedSpecifier)
+
+// given some factory that produces injectables with some generic lifecycle it works and typing is okay
+const someInjectableFactory = <P>(id: string, lifecycle: Lifecycle<P>) => getInjectable({
+  id,
+  instantiate: () => 10,
+  lifecycle,
+});


### PR DESCRIPTION
**Problem Statement:**
- The current `getInjectable` does not work well in use cases with generic `InstantiationParam`'s, this PR fixes it