### PR TITLE
feat(element-component): Introduce mechanism for conditional $prop usage with react hooks

### DIFF
--- a/packages/element-component/index.ts
+++ b/packages/element-component/index.ts
@@ -5,3 +5,13 @@ export {
 } from './src/element-component';
 
 export { getPlugin, Plugin } from './src/plugin/plugin';
+
+export type { WrapperEntry } from './src/_private/run-plugins';
+
+export type ContributeRef = (
+  refCallback: (node: HTMLElement | null) => void,
+) => void;
+
+export type ContributeProps = (
+  props: Record<string, unknown>,
+) => void;

--- a/packages/element-component/src/_private/run-plugins.ts
+++ b/packages/element-component/src/_private/run-plugins.ts
@@ -1,16 +1,22 @@
-import { MutableRefObject } from 'react';
+import { ComponentType, MutableRefObject } from 'react';
 import { Plugin } from '../plugin/plugin';
 
 type RefCallback<T> = (instance: T | null) => void;
 type Ref<T> = RefCallback<T> | MutableRefObject<T | null> | null;
 
+export type WrapperEntry = {
+  Component: ComponentType<any>;
+  props: Record<string, unknown>;
+};
+
 interface PluginResult {
   props: Record<string, unknown>;
   refs: Ref<HTMLElement>[];
+  wrappers: WrapperEntry[];
 }
 
 /**
- * Runs all plugins in a single pass, collecting refs and merging props.
+ * Runs all plugins in a single pass, collecting refs, wrappers, and merging props.
  * Plugins can set props to undefined to remove them from the output.
  */
 export const runPlugins = (
@@ -19,6 +25,7 @@ export const runPlugins = (
 ): PluginResult => {
   let currentProps = initialProps;
   const collectedRefs: Ref<HTMLElement>[] = [];
+  const collectedWrappers: WrapperEntry[] = [];
 
   for (const plugin of plugins) {
     const output = plugin(currentProps) as Record<string, unknown>;
@@ -30,6 +37,13 @@ export const runPlugins = (
         collectedRefs.push(ref);
       }
       output.ref = undefined;
+    }
+
+    // Handle $wrapper collection
+    const wrapper = output.$wrapper as WrapperEntry | undefined;
+    if (wrapper !== undefined) {
+      collectedWrappers.push(wrapper);
+      output.$wrapper = undefined;
     }
 
     // Merge input props into output (output takes precedence)
@@ -49,5 +63,9 @@ export const runPlugins = (
     currentProps = output;
   }
 
-  return { props: currentProps, refs: collectedRefs };
+  return {
+    props: currentProps,
+    refs: collectedRefs,
+    wrappers: collectedWrappers,
+  };
 };

--- a/packages/element-component/src/element-component.test.tsx
+++ b/packages/element-component/src/element-component.test.tsx
@@ -342,4 +342,477 @@ describe('element', () => {
     // @ts-expect-error
     void render(<Div href="some-string" />);
   });
+
+  describe('given plugin returning $wrapper', () => {
+    it('wraps the element with the wrapper component', () => {
+      const WrapperComponent = ({
+        someWrapperProp,
+        children,
+      }: {
+        someWrapperProp: string;
+        children: React.ReactElement;
+      }) => (
+        <div data-wrapper-test data-wrapper-prop={someWrapperProp}>
+          {children}
+        </div>
+      );
+
+      const somePlugin = getPlugin<{ $somePluginProp?: string }>(
+        ({ $somePluginProp }) => ({
+          $somePluginProp: undefined,
+
+          ...($somePluginProp
+            ? {
+                $wrapper: {
+                  Component: WrapperComponent,
+                  props: { someWrapperProp: $somePluginProp },
+                },
+              }
+            : {}),
+        }),
+      );
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(
+        <Div data-some-element-test $somePluginProp="some-value" />,
+      );
+
+      const discover = discoverFor(() => rendered);
+
+      expect(() => {
+        discover.getSingleElement('wrapper');
+      }).not.toThrow();
+
+      const wrapper = discover.getSingleElement('wrapper').discovered;
+
+      // @ts-ignore
+      expect(wrapper).toHaveAttribute('data-wrapper-prop', 'some-value');
+    });
+
+    it('does not wrap when plugin does not return $wrapper', () => {
+      const WrapperComponent = ({
+        children,
+      }: {
+        children: React.ReactElement;
+      }) => <div data-wrapper-test>{children}</div>;
+
+      const somePlugin = getPlugin<{ $somePluginProp?: string }>(
+        ({ $somePluginProp }) => ({
+          $somePluginProp: undefined,
+
+          ...($somePluginProp
+            ? {
+                $wrapper: {
+                  Component: WrapperComponent,
+                  props: {},
+                },
+              }
+            : {}),
+        }),
+      );
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test />);
+
+      const discover = discoverFor(() => rendered);
+
+      expect(() => {
+        discover.getSingleElement('wrapper');
+      }).toThrow();
+    });
+
+    it('wrapper receives contributeRef and can access the element via useState', () => {
+      let capturedElement: HTMLElement | null = null;
+
+      const WrapperComponent = ({
+        contributeRef,
+        children,
+      }: {
+        contributeRef: (cb: (node: HTMLElement | null) => void) => void;
+        children: React.ReactElement;
+      }) => {
+        const [element, setElement] = React.useState<HTMLElement | null>(null);
+        contributeRef(setElement);
+
+        capturedElement = element;
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => ({
+        $somePluginProp: undefined,
+        $wrapper: {
+          Component: WrapperComponent,
+          props: {},
+        },
+      }));
+
+      const Div = getElementComponent('div', somePlugin);
+
+      render(<Div data-some-element-test $somePluginProp />);
+
+      expect(capturedElement).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('wrapper can use contributeRef element for hook-based side effects', () => {
+      const WrapperComponent = ({
+        contributeRef,
+        children,
+      }: {
+        contributeRef: (cb: (node: HTMLElement | null) => void) => void;
+        children: React.ReactElement;
+      }) => {
+        const [element, setElement] = React.useState<HTMLElement | null>(null);
+        contributeRef(setElement);
+
+        useEffect(() => {
+          element?.classList.add('some-class-from-wrapper-hook');
+        }, [element]);
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => ({
+        $somePluginProp: undefined,
+        $wrapper: {
+          Component: WrapperComponent,
+          props: {},
+        },
+      }));
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      const discover = discoverFor(() => rendered);
+
+      expect(
+        discover
+          .getSingleElement('some-element')
+          .discovered.classList.contains('some-class-from-wrapper-hook'),
+      ).toBe(true);
+    });
+
+    it('multiple plugins returning $wrapper apply wrappers in order', () => {
+      const OuterWrapper = ({ children }: { children: React.ReactElement }) => (
+        <div data-outer-wrapper-test>{children}</div>
+      );
+
+      const InnerWrapper = ({ children }: { children: React.ReactElement }) => (
+        <div data-inner-wrapper-test>{children}</div>
+      );
+
+      const plugin1 = getPlugin<{ $plugin1?: boolean }>(() => ({
+        $plugin1: undefined,
+        $wrapper: { Component: InnerWrapper, props: {} },
+      }));
+
+      const plugin2 = getPlugin<{ $plugin2?: boolean }>(() => ({
+        $plugin2: undefined,
+        $wrapper: { Component: OuterWrapper, props: {} },
+      }));
+
+      const Div = getElementComponent('div', plugin1, plugin2);
+
+      const rendered = render(<Div data-some-element-test $plugin1 $plugin2 />);
+
+      const discover = discoverFor(() => rendered);
+
+      const outerWrapper =
+        discover.getSingleElement('outer-wrapper').discovered;
+      const innerWrapper =
+        discover.getSingleElement('inner-wrapper').discovered;
+
+      expect(outerWrapper.contains(innerWrapper)).toBe(true);
+    });
+
+    it('wrapper can use contributeProps to add props to the element', () => {
+      const WrapperComponent = ({
+        contributeProps,
+        children,
+      }: {
+        contributeProps: (props: Record<string, unknown>) => void;
+        children: React.ReactElement;
+      }) => {
+        contributeProps({ title: 'from-wrapper' });
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => ({
+        $somePluginProp: undefined,
+        $wrapper: {
+          Component: WrapperComponent,
+          props: {},
+        },
+      }));
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      const discover = discoverFor(() => rendered);
+
+      // @ts-ignore
+      expect(
+        discover.getSingleElement('some-element').discovered,
+      ).toHaveAttribute('title', 'from-wrapper');
+    });
+
+    it('wrapper can use contributeProps to add event handlers to the element', () => {
+      const onClickSpy = jest.fn();
+
+      const WrapperComponent = ({
+        contributeProps,
+        children,
+      }: {
+        contributeProps: (props: Record<string, unknown>) => void;
+        children: React.ReactElement;
+      }) => {
+        contributeProps({ onClick: onClickSpy });
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => ({
+        $somePluginProp: undefined,
+        $wrapper: {
+          Component: WrapperComponent,
+          props: {},
+        },
+      }));
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      const discover = discoverFor(() => rendered);
+      const element = discover.getSingleElement('some-element').discovered;
+
+      element.click();
+
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('contributeProps overrides plugin props', () => {
+      const WrapperComponent = ({
+        contributeProps,
+        children,
+      }: {
+        contributeProps: (props: Record<string, unknown>) => void;
+        children: React.ReactElement;
+      }) => {
+        contributeProps({ title: 'from-wrapper' });
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => ({
+        $somePluginProp: undefined,
+        title: 'from-plugin',
+        $wrapper: {
+          Component: WrapperComponent,
+          props: {},
+        },
+      }));
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      const discover = discoverFor(() => rendered);
+
+      // @ts-ignore
+      expect(
+        discover.getSingleElement('some-element').discovered,
+      ).toHaveAttribute('title', 'from-wrapper');
+    });
+
+    it('multiple wrappers contributing same event handler composes them', () => {
+      const calls: string[] = [];
+
+      const Wrapper1 = ({
+        contributeProps,
+        children,
+      }: {
+        contributeProps: (props: Record<string, unknown>) => void;
+        children: React.ReactElement;
+      }) => {
+        contributeProps({
+          onClick: () => {
+            calls.push('wrapper1');
+          },
+        });
+
+        return <>{children}</>;
+      };
+
+      const Wrapper2 = ({
+        contributeProps,
+        children,
+      }: {
+        contributeProps: (props: Record<string, unknown>) => void;
+        children: React.ReactElement;
+      }) => {
+        contributeProps({
+          onClick: () => {
+            calls.push('wrapper2');
+          },
+        });
+
+        return <>{children}</>;
+      };
+
+      const plugin1 = getPlugin<{ $plugin1?: boolean }>(() => ({
+        $plugin1: undefined,
+        $wrapper: { Component: Wrapper1, props: {} },
+      }));
+
+      const plugin2 = getPlugin<{ $plugin2?: boolean }>(() => ({
+        $plugin2: undefined,
+        $wrapper: { Component: Wrapper2, props: {} },
+      }));
+
+      const Div = getElementComponent('div', plugin1, plugin2);
+
+      const rendered = render(<Div data-some-element-test $plugin1 $plugin2 />);
+
+      const discover = discoverFor(() => rendered);
+      const element = discover.getSingleElement('some-element').discovered;
+
+      element.click();
+
+      expect(calls).toEqual(['wrapper2', 'wrapper1']);
+    });
+
+    it('contributeProps composes wrapper handler with plugin handler', () => {
+      const calls: string[] = [];
+
+      const WrapperComponent = ({
+        contributeProps,
+        children,
+      }: {
+        contributeProps: (props: Record<string, unknown>) => void;
+        children: React.ReactElement;
+      }) => {
+        contributeProps({
+          onClick: () => {
+            calls.push('wrapper');
+          },
+        });
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => ({
+        $somePluginProp: undefined,
+        onClick: () => {
+          calls.push('plugin');
+        },
+        $wrapper: {
+          Component: WrapperComponent,
+          props: {},
+        },
+      }));
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      const discover = discoverFor(() => rendered);
+      const element = discover.getSingleElement('some-element').discovered;
+
+      element.click();
+
+      expect(calls).toEqual(['plugin', 'wrapper']);
+    });
+
+    it('toggling $wrapper between present and absent does not crash', () => {
+      const hookCallCounts = { current: 0 };
+
+      const WrapperComponent = ({
+        children,
+      }: {
+        children: React.ReactElement;
+      }) => {
+        hookCallCounts.current++;
+        React.useState(0);
+
+        return <>{children}</>;
+      };
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(
+        ({ $somePluginProp }) => ({
+          $somePluginProp: undefined,
+
+          ...($somePluginProp
+            ? {
+                $wrapper: {
+                  Component: WrapperComponent,
+                  props: {},
+                },
+              }
+            : {}),
+        }),
+      );
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      expect(hookCallCounts.current).toBeGreaterThan(0);
+
+      hookCallCounts.current = 0;
+
+      rendered.rerender(<Div data-some-element-test />);
+
+      expect(hookCallCounts.current).toBe(0);
+
+      const discover = discoverFor(() => rendered);
+
+      expect(() => {
+        discover.getSingleElement('some-element');
+      }).not.toThrow();
+    });
+
+    it('$wrapper coexists with ref from the same plugin', () => {
+      const WrapperComponent = ({
+        children,
+      }: {
+        children: React.ReactElement;
+      }) => <div data-wrapper-test>{children}</div>;
+
+      const somePlugin = getPlugin<{ $somePluginProp?: boolean }>(() => {
+        const ref = useRef<HTMLElement>(null);
+
+        useEffect(() => {
+          ref.current!.classList.add('some-class-from-plugin-ref');
+        }, []);
+
+        return {
+          $somePluginProp: undefined,
+          ref,
+          $wrapper: { Component: WrapperComponent, props: {} },
+        };
+      });
+
+      const Div = getElementComponent('div', somePlugin);
+
+      const rendered = render(<Div data-some-element-test $somePluginProp />);
+
+      const discover = discoverFor(() => rendered);
+
+      expect(
+        discover
+          .getSingleElement('some-element')
+          .discovered.classList.contains('some-class-from-plugin-ref'),
+      ).toBe(true);
+
+      expect(() => {
+        discover.getSingleElement('wrapper');
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/element-component/src/element-component.tsx
+++ b/packages/element-component/src/element-component.tsx
@@ -30,9 +30,50 @@ export function getElementComponent<TagName extends TagNames>(
 
   return forwardRef(
     (unprocessedProps: Record<string, unknown>, ref: Ref<HTMLElement>) => {
-      const { props: processedProps, refs } = runPlugins(
-        unprocessedProps,
-        plugins,
+      const {
+        props: processedProps,
+        refs,
+        wrappers,
+      } = runPlugins(unprocessedProps, plugins);
+
+      const wrapperRefContributions = React.useRef<
+        ((node: HTMLElement | null) => void)[]
+      >([]);
+      wrapperRefContributions.current = [];
+
+      const contributeRef = React.useCallback(
+        (refCallback: (node: HTMLElement | null) => void) => {
+          wrapperRefContributions.current.push(refCallback);
+        },
+        [],
+      );
+
+      const elementPropsRef = React.useRef<Record<string, unknown>>({});
+      elementPropsRef.current = { ...processedProps };
+
+      const contributeProps = React.useCallback(
+        (props: Record<string, unknown>) => {
+          for (const key in props) {
+            const existing = elementPropsRef.current[key];
+            const incoming = props[key];
+
+            if (
+              typeof existing === 'function' &&
+              typeof incoming === 'function'
+            ) {
+              const prev = existing as (...args: unknown[]) => void;
+              const next = incoming as (...args: unknown[]) => void;
+
+              elementPropsRef.current[key] = (...args: unknown[]) => {
+                prev(...args);
+                next(...args);
+              };
+            } else {
+              elementPropsRef.current[key] = incoming;
+            }
+          }
+        },
+        [],
       );
 
       const callbackRef = React.useCallback(
@@ -41,14 +82,51 @@ export function getElementComponent<TagName extends TagNames>(
           for (const pluginRef of refs) {
             handleRef(node, pluginRef);
           }
+          for (const wrapperRef of wrapperRefContributions.current) {
+            wrapperRef(node);
+          }
         },
-        [ref, ...refs],
+        [ref, ...refs, wrappers.length],
       );
 
-      return <TagNameComponent {...processedProps} ref={callbackRef} />;
+      if (wrappers.length === 0) {
+        return <TagNameComponent {...processedProps} ref={callbackRef} />;
+      }
+
+      let element: React.ReactElement = (
+        <DeferredElement
+          elementPropsRef={elementPropsRef}
+          callbackRef={callbackRef}
+          TagName={TagNameComponent}
+        />
+      );
+
+      for (const { Component, props: wrapperProps } of wrappers) {
+        element = (
+          <Component
+            {...wrapperProps}
+            contributeRef={contributeRef}
+            contributeProps={contributeProps}
+          >
+            {element}
+          </Component>
+        );
+      }
+
+      return element;
     },
   );
 }
+
+const DeferredElement = ({
+  elementPropsRef,
+  callbackRef,
+  TagName,
+}: {
+  elementPropsRef: React.MutableRefObject<Record<string, unknown>>;
+  callbackRef: (node: HTMLElement | null) => void;
+  TagName: React.ElementType;
+}) => <TagName {...elementPropsRef.current} ref={callbackRef} />;
 
 const handleRef = (
   node: HTMLElement | null,

--- a/packages/injectable/extension-for-mobx/src/computedInjectMaybe.js
+++ b/packages/injectable/extension-for-mobx/src/computedInjectMaybe.js
@@ -15,7 +15,9 @@ export const _computedInjectMaybeInjectable = getInjectable({
   id: 'computed-inject-maybe-internal',
 
   instantiate: (di, { token, param }) => {
-    const computedInjectManyWithMeta = di.inject(computedInjectManyWithMetaInjectionToken);
+    const computedInjectManyWithMeta = di.inject(
+      computedInjectManyWithMetaInjectionToken,
+    );
     const computedMany = computedInjectManyWithMeta(token, param);
 
     return computed(() => {


### PR DESCRIPTION
## Summary
- Plugins can now return `$wrapper` to wrap the rendered element with arbitrary React components
- Wrappers receive `contributeRef` to access the underlying DOM element and `contributeProps` to inject additional props
- Function props (e.g. event handlers) from multiple wrappers are automatically composed

## Test plan
- [x] Wrapper renders around element when plugin returns `$wrapper`
- [x] No wrapper when plugin omits `$wrapper`
- [x] `contributeRef` provides DOM element access via `useState`
- [x] `contributeProps` adds props and event handlers to the element
- [x] Multiple wrappers apply in order and compose event handlers
- [x] `contributeProps` overrides plugin props
- [x] Toggling `$wrapper` on/off does not crash
- [x] `$wrapper` coexists with `ref` from the same plugin
- [x] All 776 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)